### PR TITLE
Fix LaTeX build by removing fontawesome

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -9,7 +9,6 @@
 \usepackage{latexsym}
 \usepackage[empty]{fullpage}
 \usepackage{titlesec}
-\usepackage{marvosym}
 \usepackage[usenames,dvipsnames]{color}
 \usepackage{verbatim}
 \usepackage{enumitem}
@@ -18,8 +17,8 @@
 \usepackage[english]{babel}
 \usepackage{tabularx}
 \usepackage{hyphenat}
-\usepackage{fontawesome}
-\input{glyphtounicode}
+% \usepackage{fontawesome}
+% \input{glyphtounicode}
 
 
 %---------- FONT OPTIONS ----------
@@ -134,17 +133,17 @@
 \begin{center}
     \textbf{\Huge \scshape Aras Güngöre} \\ \vspace{3pt}
     \small
-    \faMobile \hspace{.5pt} \href{tel:905314204536}{+90 531 420 4536}
+    \href{tel:905314204536}{+90 531 420 4536}
     $|$
-    \faAt \hspace{.5pt} \href{mailto:arasgungore09@gmail.com}{arasgungore09@gmail.com}
+    \href{mailto:arasgungore09@gmail.com}{arasgungore09@gmail.com}
     $|$
-    \faLinkedinSquare \hspace{.5pt} \href{https://www.linkedin.com/in/arasgungore}{LinkedIn}
+    \href{https://www.linkedin.com/in/arasgungore}{LinkedIn}
     $|$
-    \faGithub \hspace{.5pt} \href{https://github.com/arasgungore}{GitHub}
+    \href{https://github.com/arasgungore}{GitHub}
     $|$
-    \faGlobe \hspace{.5pt} \href{https://arasgungore.github.io}{Portfolio}
+    \href{https://arasgungore.github.io}{Portfolio}
     $|$
-    \faMapMarker \hspace{.5pt} \href{https://www.google.com/maps/place/Bogazici+University+North+Campus/@41.0863067,29.0441352,15z/data=!4m5!3m4!1s0x0:0x9d2497b07c8edb2f!8m2!3d41.0863067!4d29.0441352}{Istanbul, Turkey}
+    \href{https://www.google.com/maps/place/Bogazici+University+North+Campus/@41.0863067,29.0441352,15z/data=!4m5!3m4!1s0x0:0x9d2497b07c8edb2f!8m2!3d41.0863067!4d29.0441352}{Istanbul, Turkey}
 \end{center}
 
 


### PR DESCRIPTION
## Summary
- simplify the LaTeX preamble by removing the `fontawesome` and `marvosym` packages
- inline the icons as plain text links so the document builds without extra fonts

## Testing
- `pdflatex -interaction=nonstopmode main.tex`

------
https://chatgpt.com/codex/tasks/task_e_68445c78fc50832390451f460a82b8d1